### PR TITLE
Fix wrong qemu version

### DIFF
--- a/alpine-chroot-install
+++ b/alpine-chroot-install
@@ -205,7 +205,7 @@ alias apt_install='apt-get install -y --no-install-recommends'
 # Prints version of the specified APT package that would be installed.
 # $1: package name
 apt_pkgver() {
-	apt-cache policy "$1" | sed -En 's/^\s*Candidate:( [0-9]+:| )(\S+).*/\2/p'
+	LC_ALL=C apt-cache policy "$1" | sed -En 's/^\s*Candidate:( [0-9]+:| )(\S+).*/\2/p'
 }
 
 # Prints version of the given QEMU binary.


### PR DESCRIPTION
Fix for https://github.com/alpinelinux/alpine-chroot-install/issues/13 and maybe others too
Add LC_ALL=C because of different wording in apt-cache from non english locales