### PR TITLE
Test bind directory and remove one use of cat

### DIFF
--- a/alpine-chroot-install
+++ b/alpine-chroot-install
@@ -221,7 +221,7 @@ gen_destroy_script() {
 		[ "$(id -u)" -eq 0 ] || _sudo='sudo'
 
 		# Unmounts all filesystem under the specified directory tree.
-		cat /proc/mounts | cut -d' ' -f2 | grep "^$SCRIPT_DIR." | sort -r | while read path; do
+		cut -d' ' -f2 /proc/mounts | grep "^$SCRIPT_DIR." | sort -r | while read path; do
 			echo "Unmounting $path" >&2
 			$_sudo umount -fn "$path" || exit 1
 		done

--- a/alpine-chroot-install
+++ b/alpine-chroot-install
@@ -388,7 +388,7 @@ if [ -L /dev/shm ] && [ -d /run/shm ]; then
 	mount --make-private run/shm
 fi
 
-if [ "$BIND_DIR" ]; then
+if [ -d "$BIND_DIR" ]; then
 	mkdir -p "${CHROOT_DIR}${BIND_DIR}"
 	mount -v --bind "$BIND_DIR" "${CHROOT_DIR}${BIND_DIR}"
 	mount --make-private "${CHROOT_DIR}${BIND_DIR}"


### PR DESCRIPTION
Testing that $BIND_DIR is a valid directory is a good check I think prior to trying to mount it and it also let's you pass an invalid path as a way to prevent mounting a directory in the chroot even when running the script under /home, eg. `-i none`

Other change is to use cut directly instead of cat.